### PR TITLE
CI: cache binaries test

### DIFF
--- a/.github/workflows/build-docker.yml
+++ b/.github/workflows/build-docker.yml
@@ -19,6 +19,20 @@ jobs:
         run: |
           sudo apt-get install -y transmission-cli
 
+      - name: get version from hashes.txt
+        id: hashes_version
+        run: |
+          HASHES_URL="https://www.getmonero.org/downloads/hashes.txt"
+          curl -sL $HASHES_URL -o hashes.txt
+          version=$(awk '/monero-source-v/ {print $2}' "hashes.txt" | awk -F".tar.bz2" '{print $1}' | awk -F"-" '{print $3}') 
+          echo "version=$version" >> $GITHUB_OUTPUT
+      - uses: actions/cache@v4
+        id: binaries_cache
+        if: "!startsWith(github.ref, 'refs/tags/v')"
+        with:
+          path: ./downloads
+          key: monero-binaries-${{ steps.hashes_version.outputs.version }}
+
       - name: Run remote profile
         run: |
           docker compose --profile remote up


### PR DESCRIPTION
- use cache for binaries
- force download on tag and new version

this does not save much time but stops me ddosing getmonero while building this 