### PR TITLE
Avoid rebuilding .torrent files if version already exists

### DIFF
--- a/create_monero_torrent.sh
+++ b/create_monero_torrent.sh
@@ -62,6 +62,12 @@ cli_version=$(awk '/monero-source-v/ {print $2}' "$OUTPUT_DIR/hashes.txt" | awk 
 gui_version=$(awk '/monero-gui-source-v/ {print $2}' "$OUTPUT_DIR/hashes.txt" | awk -F".tar.bz2" '{print $1}' | awk -F"-" '{print $4}')
 cli_torrent="monero-$cli_version"
 gui_torrent="monero-gui-$gui_version"
+
+if [ -f "$TORRENT_DIR/$cli_torrent.torrent" ] && [ -f "$TORRENT_DIR/$gui_torrent.torrent" ]; then
+    echo "Torrents for $cli_torrent and $gui_torrent already exist. Exiting."
+    exit 0
+fi
+
 gui_torrent_comment="Monero GUI $gui_version"
 cli_torrent_comment="Monero CLI $cli_version"
 


### PR DESCRIPTION
Currently the script recreates the CLI and GUI .torrent files every time it is run, even if the current version has already been built. This change adds an early-exit check after determining the CLI and GUI versions. If the corresponding .torrent files already exist in the watch directory, the script exits. This is especially useful for automated runs avoiding unnecessary triggers for inotify watchers or torrent clients watching new .torrent files.